### PR TITLE
Fixing Typos for DynamoDB and RDBMS notebooks

### DIFF
--- a/examples/dynamodb-with-spark.ipynb
+++ b/examples/dynamodb-with-spark.ipynb
@@ -105,7 +105,7 @@
    "id": "664d194a",
    "metadata": {},
    "source": [
-    "## Read data using Pyspark"
+    "## Read data using Scala"
    ]
   },
   {

--- a/examples/jdbc-rdbms-with-spark.ipynb
+++ b/examples/jdbc-rdbms-with-spark.ipynb
@@ -5,7 +5,7 @@
    "id": "44cde1cc",
    "metadata": {},
    "source": [
-    "# Connect RDBS using jdbc connector from EMR Studio Notebook using Pyspark, Spark Scala, and SparkR\n",
+    "# Connect RDBMS using jdbc connector from EMR Studio Notebook using Pyspark, Spark Scala, and SparkR\n",
     "\n",
     "#### Topics covered in this example\n",
     "\n",


### PR DESCRIPTION
1) Fixed the typo language for DynamoDB notebook from PySpark to Scala 
2) Fixed the typo for rdbms notebook in heading to RDBMS instead of RDBS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
